### PR TITLE
se soluciona problema de desoconexión en la comunicación ethernet

### DIFF
--- a/src/HMIcomRTU.py
+++ b/src/HMIcomRTU.py
@@ -296,8 +296,8 @@ def RTUTranslate(a_RTUDataRx):
 
     depurador(2, "HMIcomRTU", "****************************************")
     depurador(2, "HMIcomRTU", "- Recibiendo...")
-    depurador(3, "HMIcomRTU","- Rx<-- RTUDataByte   :" + str(a_RTUDataByte))
-    depurador(3, "HMIcomRTU","- Rx<-- RTUDataString :" + str(a_RTUDataString))
+    depurador(3, "HMIcomRTU","- Rx<-- RTUDataRx   :" + str(a_RTUDataRx))
+    #depurador(3, "HMIcomRTU","- Rx<-- RTUDataString :" + str(a_RTUDataString))
     
         # Conversión del resultado de resolver a ángulos. -Byte- a -Float-
     #if(True):
@@ -310,7 +310,7 @@ def RTUTranslate(a_RTUDataRx):
         f_velActArm = int(a_RTUDataRx[2])
         f_velActPole = int(a_RTUDataRx[3])
         
-         # Se convierten los datos de -Byte- a -String- mediante -decode()-.
+         # Se convierten lose datos de -Byte- a -String- mediante -decode()-.
         b_cwLimitArm = a_RTUDataRx[4].decode()
         b_ccwLimitArm = a_RTUDataRx[5].decode()
         b_cwLimitPole = a_RTUDataRx[6].decode()

--- a/src/hmi_SM13.py
+++ b/src/hmi_SM13.py
@@ -2551,6 +2551,8 @@ def conversor(ui_res_act_pole, ui_res_act_arm, f_ang_cmd_pole, f_ang_cmd_arm, s_
     f_MAX_GRADOS = 359.999
     ui_PENDIENTE_RES_ARM = 182.148 # (ctas/grados)
     ui_PENDIENTE_RES_POLE = 182.148 # (ctas/grados)
+    ui_cruce_por_cero_res_pole = 0;
+    ui_cruce_por_cero_res_arm = 0;
 
     if(s_msg == "cuenta_a_angulo"):
         # Se verifica el valor actual de encorder para saber qué valor de cruce por cero utilizar.


### PR DESCRIPTION
revisar si son correctas las asignaciones  al valor "0", en las definiciones de las variables -hmi_SM13.py-:
    ui_cruce_por_cero_res_pole = 0;
    ui_cruce_por_cero_res_arm = 0;


